### PR TITLE
Add travis yml file for tests.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: go
+go:
+- 1.3
+- 1.4
+
+install:
+- go get golang.org/x/tools/cmd/vet
+
+script:
+- go fmt ./...
+- go vet ./...
+- go test -i -race ./...
+- go test -v -race ./...


### PR DESCRIPTION
I've added support to termtables for travis CI integrations. the build is passing in the branch as well.

I've also opted to support both go 1.3 and go 1.4 for now in the builds, but we can change that at any point. 

FYI PR @krobertson @alextoombs 