### PR TITLE
Fix conflicting build flags in the locale package

### DIFF
--- a/locale/windows.go
+++ b/locale/windows.go
@@ -1,6 +1,6 @@
 // Copyright 2014 Apcera Inc. All rights reserved.
 
-// +build windows,!cgo
+// +build windows
 
 package locale
 


### PR DESCRIPTION
This fixes an issue where conflicting build flags were causing the locale
package to fail to build on Windows. The windows.go file had both windows
and !cgo, which apparently conflicted when building natively on Windows,
but not when cross compiling.

I thought our builds on Windows were native, but they weren't, and when
changing it to be native, it raised awareness. Don't know why cross
compiling to Windows didn't have this issue, but it one reason I dislike
cross compilation too.

FYI PR @philpennock @tcahill @zquestz 