### PR TITLE
add support for calling AddHeaders multiple times

### DIFF
--- a/table.go
+++ b/table.go
@@ -146,7 +146,7 @@ func (t *Table) AddTitle(title interface{}) {
 
 // AddHeaders supplies column headers for the table.
 func (t *Table) AddHeaders(headers ...interface{}) {
-	t.headers = headers[:]
+	t.headers = append(t.headers, headers...)
 }
 
 // SetAlign changes the alignment for elements in a column of the table;

--- a/table_test.go
+++ b/table_test.go
@@ -434,3 +434,19 @@ func TestTableWithFullwidthChars(t *testing.T) {
 
 	checkRendersTo(t, table, expected)
 }
+
+func TestTableMultipleAddHeader(t *testing.T) {
+	expected := "" +
+		"+--------------+--------+-------+\n" +
+		"| First column | Second | Third |\n" +
+		"+--------------+--------+-------+\n" +
+		"| 2            | 3      | 5     |\n" +
+		"+--------------+--------+-------+\n"
+
+	table := CreateTable()
+	table.AddHeaders("First column", "Second")
+	table.AddHeaders("Third")
+	table.AddRow(2, 3, 5)
+
+	checkRendersTo(t, table, expected)
+}


### PR DESCRIPTION
In old version adding all headers at a time are not always сonveniently. For example, that was my code for old version (`headers` is `[]string`)
```

	headers := make([]interface{}, len(tt.inputs)+len(tt.outputs))
	for i, v := range tt.inputs {
		headers[i] = v
	}
	for i, v := range tt.outputs {
		headers[len(tt.inputs)+i] = v
	}
	table.AddHeaders(headers...)
```
Now, this code rewrote to:
```
	for _, v := range tt.inputs {
		table.AddHeaders(v)
	}
	for _, v := range tt.outputs {
		table.AddHeaders(v)
	}
```
And even more less code.