### PR TITLE
travis: Updated test configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: go
 go:
-- 1.3
-- 1.4
+  - 1.5.4
+  - 1.6.2
+  - tip
 
-install:
-- go get golang.org/x/tools/cmd/vet
+env:
+  global:
+    - GO15VENDOREXPERIMENT=1
 
 script:
 - go fmt ./...


### PR DESCRIPTION
This updates the travis config to focus on testing 1.5, 1.6, and Go
tip. This also changes the install steps to not fetch go tools, as it is
now available and was breaking the test runs. Now it is more in line
with apcera/util's config.

@alextoombs @jpoler :grinning: 