### PR TITLE
Update travis file to test Go 1.6.X and 1.7.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,9 @@
 language: go
 go:
-  - 1.5.4
-  - 1.6.2
+  - 1.6
+  - 1.7
   - tip
 
-env:
-  global:
-    - GO15VENDOREXPERIMENT=1
-
 script:
-- go fmt ./...
 - go vet ./...
-- go test -i -race ./...
 - go test -v -race ./...


### PR DESCRIPTION
- Update the travis file to test on current version of Go.
- Remove `GO15VENDOREXPERIMENT=1` which is default as of Go 1.6.
- Remove redundant `go test -i` command.
- Remove `go fmt` command that didn't do anything.