### PR TITLE
render: Fix bug to rerender tables; switch to byte buffers.

### DIFF
--- a/table_test.go
+++ b/table_test.go
@@ -93,6 +93,34 @@ func TestTableWithHeader(t *testing.T) {
 	checkRendersTo(t, table, expected)
 }
 
+// TestTableWithHeaderMultipleTimes ensures that printing a table with headers
+// multiple times continues to render correctly.
+func TestTableWithHeaderMultipleTimes(t *testing.T) {
+	expected := "" +
+		"+-------------------+\n" +
+		"|      Example      |\n" +
+		"+-----------+-------+\n" +
+		"| Name      | Value |\n" +
+		"+-----------+-------+\n" +
+		"| hey       | you   |\n" +
+		"| ken       | 1234  |\n" +
+		"| derek     | 3.14  |\n" +
+		"| derek too | 3.15  |\n" +
+		"+-----------+-------+\n"
+
+	table := CreateTable()
+
+	table.AddTitle("Example")
+	table.AddHeaders("Name", "Value")
+	table.AddRow("hey", "you")
+	table.AddRow("ken", 1234)
+	table.AddRow("derek", 3.14)
+	table.AddRow("derek too", 3.1456788)
+
+	checkRendersTo(t, table, expected)
+	checkRendersTo(t, table, expected)
+}
+
 func TestTableTitleWidthAdjusts(t *testing.T) {
 	expected := "" +
 		"+---------------------------+\n" +
@@ -449,4 +477,48 @@ func TestTableMultipleAddHeader(t *testing.T) {
 	table.AddRow(2, 3, 5)
 
 	checkRendersTo(t, table, expected)
+}
+
+func createTestTable() *Table {
+	table := CreateTable()
+	header := []interface{}{}
+	for i := 0; i < 50; i++ {
+		header = append(header, "First Column")
+	}
+	table.AddHeaders(header...)
+	for i := 0; i < 3000; i++ {
+		row := []interface{}{}
+		for i := 0; i < 50; i++ {
+			row = append(row, "First row value")
+		}
+		table.AddRow(row...)
+	}
+	return table
+}
+
+func BenchmarkTableRenderTerminal(b *testing.B) {
+	table := createTestTable()
+	table.SetModeTerminal()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		table.Render()
+	}
+}
+
+func BenchmarkTableRenderMarkdown(b *testing.B) {
+	table := createTestTable()
+	table.SetModeMarkdown()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		table.Render()
+	}
+}
+
+func BenchmarkTableRenderHTML(b *testing.B) {
+	table := createTestTable()
+	table.SetModeHTML()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		table.Render()
+	}
 }


### PR DESCRIPTION
The elements of the table were being modified on each call
to Render, leading to headers and titles being compounded.
This fixes the bug by utilizing a deep-ish copy of the table.

In addition, I noticed raw string concatenation in Render
which I swapped out for bytes.Buffer calls which led to a
95% reduction in the duration of the call.

Fixes #28 

Pulled benchmarks from #35 as they proved useful here too.